### PR TITLE
option to save extra user settings in DB

### DIFF
--- a/src/app/currency/currency.service.ts
+++ b/src/app/currency/currency.service.ts
@@ -84,4 +84,17 @@ export class CurrencyService {
 
     return rate;
   }
+
+
+  recalculateCurrencyRate(currency: CURRENCIES, rates: Record<CURRENCIES, number>): Record<CURRENCIES, number> {
+    const currentCurrencyRate = rates[currency];
+
+    for (const currency in rates) {
+      if (rates.hasOwnProperty(currency)) {
+        rates[currency] = rates[currency] / currentCurrencyRate;
+      }
+    }
+
+    return rates
+  }
 }

--- a/src/app/currency/currency.service.ts
+++ b/src/app/currency/currency.service.ts
@@ -85,7 +85,6 @@ export class CurrencyService {
     return rate;
   }
 
-
   recalculateCurrencyRate(currency: CURRENCIES, rates: Record<CURRENCIES, number>): Record<CURRENCIES, number> {
     const currentCurrencyRate = rates[currency];
 
@@ -95,6 +94,6 @@ export class CurrencyService {
       }
     }
 
-    return rates
+    return rates;
   }
 }

--- a/src/app/expense/expense.service.ts
+++ b/src/app/expense/expense.service.ts
@@ -46,7 +46,7 @@ export class ExpenseService {
         comments: inputDto.comments,
         createdAt: inputDto.createdAt,
         currency: inputDto.currency,
-        exchangeRates: currentRates,
+        exchangeRates: currentCurrencyRate,
       });
       const createdExpanse = await newExpansesInstance.save();
 

--- a/src/app/expense/expense.service.ts
+++ b/src/app/expense/expense.service.ts
@@ -33,10 +33,7 @@ export class ExpenseService {
       const currentRates = (await this.currencyService.getRatesByDate(new Date(inputDto.createdAt))).rates;
 
       // recalculate currencyRate to expense currency
-      const currentCurrencyRate = this.currencyService.recalculateCurrencyRate(
-        inputDto.currency,
-        currentRates,
-      );
+      const currentCurrencyRate = this.currencyService.recalculateCurrencyRate(inputDto.currency, currentRates);
 
       const newExpansesInstance = new this.expensesModel({
         userId: userId,

--- a/src/app/expense/expense.service.ts
+++ b/src/app/expense/expense.service.ts
@@ -33,13 +33,10 @@ export class ExpenseService {
       const currentRates = (await this.currencyService.getRatesByDate(new Date(inputDto.createdAt))).rates;
 
       // recalculate currencyRate to expense currency
-      const currentCurrencyRate = currentRates[inputDto.currency];
-
-      for (const currency in currentRates) {
-        if (currentRates.hasOwnProperty(currency)) {
-          currentRates[currency] = currentRates[currency] / currentCurrencyRate;
-        }
-      }
+      const currentCurrencyRate = this.currencyService.recalculateCurrencyRate(
+        inputDto.currency,
+        currentRates,
+      );
 
       const newExpansesInstance = new this.expensesModel({
         userId: userId,
@@ -200,6 +197,11 @@ export class ExpenseService {
 
     if (inputDto.createdAt && inputDto.createdAt !== foundExpanse.createdAt) {
       exchangeRates = (await this.currencyService.getRatesByDate(new Date(inputDto.createdAt))).rates;
+    }
+
+    //if currency is changed, we need to recalculate exchange rates
+    if (inputDto.currency && inputDto.currency !== foundExpanse.currency) {
+      exchangeRates = this.currencyService.recalculateCurrencyRate(inputDto.currency, exchangeRates);
     }
 
     return this.expensesModel.findByIdAndUpdate(expensesId, { ...inputDto, exchangeRates }, { new: true }).lean();

--- a/src/app/user-config/dto/user-config-input.dto.ts
+++ b/src/app/user-config/dto/user-config-input.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsEnum } from 'class-validator';
+import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
 import { CURRENCIES } from 'src/common/interfaces/currencies.enum';
 import { LANGUAGES } from 'src/common/interfaces/languages.enum';
 import { THEME_ENUM } from '../constants/theme.enum';
@@ -77,4 +77,12 @@ export class UserConfigInputDto {
   })
   @IsBoolean()
   showSharedSources: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Show expenses in each currency',
+  })
+  @IsOptional()
+  @IsBoolean()
+  showExpensesInEachCurrency?: boolean;
 }

--- a/src/app/user-config/dto/user-config-output.dto.ts
+++ b/src/app/user-config/dto/user-config-output.dto.ts
@@ -72,4 +72,10 @@ export class UserConfigOutputDto {
     description: 'Show shared sources',
   })
   showSharedSources: boolean;
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Show expenses in each currency',
+  })
+  showExpensesInEachCurrency: boolean;
 }

--- a/src/app/user-config/model/user-config.model.ts
+++ b/src/app/user-config/model/user-config.model.ts
@@ -39,6 +39,9 @@ export class UserConfig {
 
   @Prop({ required: true })
   showSourceColours: boolean;
+
+  @Prop({ required: false })
+  showExpensesInEachCurrency?: boolean;
 }
 
 export const UserConfigSchema = SchemaFactory.createForClass(UserConfig);


### PR DESCRIPTION
add option to save "show expense in each currency" in DB (user settings to be updated on FE.

fixed recalculating expenses after updating currency (in case when user set incorrect currency and then update it)

#155