### PR TITLE
Add Gemini Receipt Auto-Save Flow with Robust Prompting and CI Secrets

### DIFF
--- a/.github/workflows/preview-cd.yml
+++ b/.github/workflows/preview-cd.yml
@@ -25,6 +25,7 @@ env:
   GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
   GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
 on:
   pull_request:
@@ -105,6 +106,7 @@ jobs:
           GOOGLE_CLIENT_ID: test-google-client-id
           GOOGLE_CLIENT_SECRET: test-google-client-secret
           GOOGLE_CALLBACK_URL: http://localhost:3000/auth/google/callback
+          GEMINI_API_KEY: test-gemini-api-key
         run: pnpm test
 
       - name: Build project

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -24,6 +24,7 @@ env:
   GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
   GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
 on:
   push:
@@ -69,6 +70,7 @@ jobs:
           echo "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" >> .env
           echo "GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}" >> .env
           echo "GOOGLE_CALLBACK_URL=${GOOGLE_CALLBACK_URL}" >> .env
+          echo "GEMINI_API_KEY=${GEMINI_API_KEY}" >> .env
 
       - name: Copy Build Artefacts and .env to VPS
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+NestJS code sits in `src/`: feature modules under `src/app`, shared helpers in `src/common`, `src/guards`, `src/pipes`, and `src/utils`. Configuration bootstrappers live in `src/configs`, while database tasks belong in `src/migrations`. Tests reside in `test/` with reusable fixtures in `test/test-utils.ts`. The `dist/` directory is build output—never edit it. Housekeeping scripts are stored in `scripts/`.
+
+## Build, Test, and Development Commands
+Run commands from the repository root with pnpm: `pnpm dev` starts the watched Nest server, `pnpm build` compiles TypeScript and uploads Sentry sourcemaps, and `pnpm start:prod` runs the compiled app. Use `pnpm lint`, `pnpm format`, or `pnpm format:fix` to enforce style. `pnpm test`, `pnpm test:e2e`, and `pnpm test:cov` cover unit, e2e, and coverage scenarios; `pnpm typecheck` surfaces type regressions.
+
+## Coding Style & Naming Conventions
+Prettier enforces 2-space indentation, single quotes, and trailing commas where valid. ESLint (with the `unused-imports` plugin) keeps modules tidy, so resolve lint warnings before pushing. Classes, DTOs, and providers use PascalCase (e.g., `CreateExpenseDto`), while functions, variables, and file names stay camelCase or kebab-case (`database-backup.service.ts`). Follow NestJS naming (`*.module.ts`, `*.service.ts`) and colocate DTOs and validators with their feature module.
+
+## Testing Guidelines
+All tests use Jest. Place new specs in `test/` or alongside the feature they cover, ending files with `.spec.ts`. Favor behavior-focused `describe` blocks, and reuse helpers from `test/test-utils.ts` for environment setup. Ensure `pnpm test` passes before committing; run `pnpm test:cov` on larger changes to watch coverage.
+
+## Commit & Pull Request Guidelines
+Use `<type>: <imperative summary>` commit subjects (`fix: correct CLIENT_URLS JSON format`) and keep each commit scoped to one concern. Pull requests should include a concise summary, linked issues, test evidence (`pnpm test` output or API screenshots), and note any configuration or migration changes. Flag security-sensitive updates so reviewers can verify `.env` expectations.
+
+## Security & Configuration Tips
+Settings load through `@nestjs/config`; keep secrets in a non-committed `.env`. Document new environment keys in `README.md` and provide safe defaults in configuration factories so local and CI runs stay predictable.

--- a/src/app/expense/constants/receipt-ai-error.constant.ts
+++ b/src/app/expense/constants/receipt-ai-error.constant.ts
@@ -1,0 +1,24 @@
+export const RECEIPT_AI_ERROR = {
+  GEMINI_REJECTED: 'receiptAi.errors.geminiRejected',
+  RECOGNITION_FAILED: 'receiptAi.errors.recognitionFailed',
+  INVALID_JSON: 'receiptAi.errors.invalidJson',
+  UNKNOWN: 'receiptAi.errors.unknown',
+  NO_EXPENSE: 'receiptAi.errors.noExpense',
+  MISSING_IMAGE: 'receiptAi.errors.missingImage',
+  UNSUPPORTED_IMAGE_TYPE: 'receiptAi.errors.unsupportedImageType',
+  NO_CATEGORIES: 'receiptAi.errors.noCategories',
+  NO_PAYMENT_SOURCES: 'receiptAi.errors.noPaymentSources',
+  INVALID_AMOUNT: 'receiptAi.errors.invalidAmount',
+  CATEGORY_NOT_SELECTED: 'receiptAi.errors.categoryNotSelected',
+  PAYMENT_SOURCE_NOT_SELECTED: 'receiptAi.errors.paymentSourceNotSelected',
+  UNKNOWN_CATEGORY_ID: 'receiptAi.errors.unknownCategoryId',
+  UNKNOWN_PAYMENT_SOURCE_ID: 'receiptAi.errors.unknownPaymentSourceId',
+  INVALID_RESPONSE: 'receiptAi.errors.invalidResponse',
+  NO_CANDIDATES: 'receiptAi.errors.noCandidates',
+  NO_TEXT_PART: 'receiptAi.errors.noTextPart',
+} as const;
+
+export const RECEIPT_AI_PROMPT = {
+  MAX_COMMENT_LENGTH: 100,
+  REQUEST_TIMEOUT_MS: 20000,
+} as const;

--- a/src/app/expense/decorators/parse-receipt-sw.decorator.ts
+++ b/src/app/expense/decorators/parse-receipt-sw.decorator.ts
@@ -1,0 +1,49 @@
+import { applyDecorators, HttpCode } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ReceiptParseResponseDto } from '../dto/receipt-expense-response.dto';
+
+export function ParseReceiptSwDec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Распознать чек с помощью Gemini',
+      description: `Принимает фотографию чека, автоматически подбирает категории, источники трат и валюту пользователя, и сразу сохраняет трату в базе.
+
+Требуется:
+- токен авторизации в заголовке
+- файл чека (поле receipt) в multipart/form-data`,
+    }),
+    ApiBearerAuth(),
+    ApiConsumes('multipart/form-data'),
+    HttpCode(200),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          receipt: {
+            type: 'string',
+            format: 'binary',
+            description: 'Изображение чека (JPEG, PNG или WEBP).',
+          },
+        },
+        required: ['receipt'],
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Сохраненная трата и краткое пояснение от модели.',
+      type: ReceiptParseResponseDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Ошибка валидации входных данных (невалидный файл).',
+    }),
+    ApiResponse({
+      status: 422,
+      description: 'Модель не смогла распознать чек или вернула некорректные данные.',
+    }),
+    ApiResponse({
+      status: 500,
+      description: 'Системная ошибка либо проблемы с ключом Gemini.',
+    }),
+  );
+}

--- a/src/app/expense/dto/receipt-expense-response.dto.ts
+++ b/src/app/expense/dto/receipt-expense-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ExpenseOutputDto } from './expense-output.dto';
+
+export class ReceiptParseResponseDto {
+  @ApiProperty({ type: ExpenseOutputDto })
+  expense: ExpenseOutputDto;
+
+  @ApiPropertyOptional({
+    description: 'Пояснение от модели, почему были выбраны такие значения.',
+    example: 'Подсумма совпала с категорией "Продукты", выбрана карта как источник оплаты.',
+  })
+  reason?: string | null;
+}

--- a/src/app/expense/expense.module.ts
+++ b/src/app/expense/expense.module.ts
@@ -1,14 +1,19 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
+import { HttpModule } from '@nestjs/axios';
 import { AccessControlModule } from '../access-control/access-control.module';
 import { AccessControlService } from '../access-control/access-control.service';
 import { AccessJwtStrategy } from '../auth/strategies/access-jwt.strategy';
 import { CurrencyModule } from '../currency/currency.module';
 import { FamilyBudgetModule } from '../family-budget/family-budget.module';
 import { User, UserSchema } from '../user/models/user.model';
+import { Category, CategorySchema } from '../category/models/category.model';
+import { PaymentSource, PaymentSourceSchema } from '../payment-source/models/payment-source.model';
+import { UserConfig, UserConfigSchema } from '../user-config/model/user-config.model';
 import { ExpenseController } from './expense.controller';
 import { ExpenseService } from './expense.service';
+import { ReceiptAiService } from './receipt-ai.service';
 import { ExpansesSchema, Expense } from './models/expense.model';
 import { CronExpenseModule } from '../cron-expenses/cron-expense.module';
 
@@ -16,14 +21,18 @@ import { CronExpenseModule } from '../cron-expenses/cron-expense.module';
   imports: [
     MongooseModule.forFeature([{ name: Expense.name, schema: ExpansesSchema, collection: 'Expenses' }]),
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema, collection: 'User' }]),
+    MongooseModule.forFeature([{ name: Category.name, schema: CategorySchema, collection: 'Category' }]),
+    MongooseModule.forFeature([{ name: PaymentSource.name, schema: PaymentSourceSchema, collection: 'PaymentSource' }]),
+    MongooseModule.forFeature([{ name: UserConfig.name, schema: UserConfigSchema, collection: 'UserConfig' }]),
     ConfigModule,
+    HttpModule,
     AccessControlModule,
     CurrencyModule,
     FamilyBudgetModule,
     forwardRef(() => CronExpenseModule),
   ],
   controllers: [ExpenseController],
-  providers: [ExpenseService, AccessControlService, AccessJwtStrategy],
+  providers: [ExpenseService, ReceiptAiService, AccessControlService, AccessJwtStrategy],
   exports: [ExpenseService],
 })
 export class ExpenseModule {}

--- a/src/app/expense/receipt-ai.service.spec.ts
+++ b/src/app/expense/receipt-ai.service.spec.ts
@@ -1,0 +1,206 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { of } from 'rxjs';
+import { ReceiptAiService } from './receipt-ai.service';
+import { UnprocessableEntityException } from '@nestjs/common';
+
+const createFile = (): Express.Multer.File =>
+  ({
+    buffer: Buffer.from('image-bytes'),
+    mimetype: 'image/png',
+    size: 12,
+    fieldname: 'receipt',
+    originalname: 'receipt.png',
+    encoding: '7bit',
+    stream: null,
+    destination: undefined,
+    filename: undefined,
+    path: undefined,
+  }) as unknown as Express.Multer.File;
+
+const mockResponse = (payload: unknown) =>
+  ({
+    data: payload,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  }) as unknown;
+
+describe('ReceiptAiService', () => {
+  let service: ReceiptAiService;
+  let httpService: Pick<HttpService, 'post'>;
+  let configService: Pick<ConfigService, 'get'>;
+  let categoryModel: any;
+  let paymentSourceModel: any;
+  let userConfigModel: any;
+
+  beforeEach(() => {
+    httpService = {
+      post: jest.fn(),
+    } as unknown as Pick<HttpService, 'post'>;
+
+    configService = {
+      get: jest.fn().mockReturnValue('test-api-key'),
+    } as unknown as Pick<ConfigService, 'get'>;
+
+    const categoryQuery = {
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: 'cat-1', title: 'Groceries' }]),
+    };
+    const paymentSourceQuery = {
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([{ _id: 'ps-1', title: 'Card' }]),
+    };
+    const userConfigQuery = {
+      select: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({ currency: 'USD' }),
+    };
+
+    categoryModel = {
+      find: jest.fn().mockReturnValue(categoryQuery),
+    };
+    paymentSourceModel = {
+      find: jest.fn().mockReturnValue(paymentSourceQuery),
+    };
+    userConfigModel = {
+      findOne: jest.fn().mockReturnValue(userConfigQuery),
+    };
+
+    service = new ReceiptAiService(
+      configService as ConfigService,
+      httpService as HttpService,
+      categoryModel,
+      paymentSourceModel,
+      userConfigModel,
+    );
+  });
+
+  it('returns normalized expense input when receipt is recognized', async () => {
+    const candidate = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '{"recognized":true,"reason":"Parsed successfully","expense":{"amount":4500.5,"currency":"usd","categoryId":"cat-1","paymentSourceId":"ps-1","comments":"Grocery run","createdAt":"2024-06-12"}}',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    (httpService.post as jest.Mock).mockReturnValue(of(mockResponse(candidate)));
+
+    const result = await service.parseReceipt({
+      image: createFile(),
+      userId: 'user-1',
+    });
+
+    expect(categoryModel.find).toHaveBeenCalledWith({ userId: 'user-1' });
+    expect(paymentSourceModel.find).toHaveBeenCalledWith({ userId: 'user-1' });
+    expect(userConfigModel.findOne).toHaveBeenCalledWith({ userId: 'user-1' });
+
+    expect(result.expenseInput.amount).toBe(4500.5);
+    expect(result.expenseInput.currency).toBe('USD');
+    expect(result.expenseInput.categoryId).toBe('cat-1');
+    expect(result.expenseInput.paymentSourceId).toBe('ps-1');
+    expect(result.expenseInput.comments).toBe('Grocery run');
+    expect(result.expenseInput.createdAt).toBeInstanceOf(Date);
+    expect(result.reason).toBe('Parsed successfully');
+  });
+
+  it('throws when receipt is not recognized', async () => {
+    const candidate = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '{"recognized":false,"reason":"Blurry photo","expense":null}',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    (httpService.post as jest.Mock).mockReturnValue(of(mockResponse(candidate)));
+
+    await expect(
+      service.parseReceipt({
+        image: createFile(),
+        userId: 'user-1',
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('throws when model returns unknown category id', async () => {
+    const candidate = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '{"recognized":true,"reason":null,"expense":{"amount":1200,"currency":"USD","categoryId":"unknown","paymentSourceId":"ps-1"}}',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    (httpService.post as jest.Mock).mockReturnValue(of(mockResponse(candidate)));
+
+    await expect(
+      service.parseReceipt({
+        image: createFile(),
+        userId: 'user-1',
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('retries when model returns non-json answer', async () => {
+    const invalidCandidate = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: 'Here is what I found: amount 1000',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const validCandidate = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: '{"recognized":true,"reason":null,"expense":{"amount":1000,"currency":null,"categoryId":"cat-1","paymentSourceId":"ps-1","comments":null,"createdAt":null}}',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    (httpService.post as jest.Mock)
+      .mockReturnValueOnce(of(mockResponse(invalidCandidate)))
+      .mockReturnValueOnce(of(mockResponse(validCandidate)));
+
+    const result = await service.parseReceipt({
+      image: createFile(),
+      userId: 'user-1',
+    });
+
+    expect((httpService.post as jest.Mock).mock.calls.length).toBe(2);
+    expect(result.expenseInput.amount).toBe(1000);
+    expect(result.expenseInput.currency).toBe('USD'); // fallback to user config currency
+  });
+});

--- a/src/app/expense/receipt-ai.service.ts
+++ b/src/app/expense/receipt-ai.service.ts
@@ -1,0 +1,431 @@
+import { HttpService } from '@nestjs/axios';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { firstValueFrom } from 'rxjs';
+import { Category, CategoryDocument } from '../category/models/category.model';
+import { PaymentSource, PaymentSourceDocument } from '../payment-source/models/payment-source.model';
+import { UserConfig, UserConfigDocument } from '../user-config/model/user-config.model';
+import { ExpenseInputDto } from './dto/expense-input.dto';
+import { CURRENCIES } from '../../common/interfaces/currencies.enum';
+
+type ReceiptOption = {
+  id: string;
+  name: string;
+};
+
+type ReceiptParseParams = {
+  image: Express.Multer.File;
+  userId: string;
+};
+
+type GeminiExpenseResponse = {
+  recognized: boolean;
+  reason?: string | null;
+  expense?: {
+    amount?: number | string;
+    currency?: string | null;
+    categoryId?: string;
+    paymentSourceId?: string;
+    comments?: string | null;
+    createdAt?: string | null;
+  } | null;
+};
+
+type ReceiptParseResult = {
+  expenseInput: ExpenseInputDto;
+  reason?: string | null;
+};
+
+const MAX_ATTEMPTS = 3;
+
+@Injectable()
+export class ReceiptAiService {
+  private readonly logger = new Logger(ReceiptAiService.name);
+  private readonly modelId = 'gemini-2.0-flash-001';
+  private readonly endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${this.modelId}:generateContent`;
+  private readonly supportedMimeTypes = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpService: HttpService,
+    @InjectModel(Category.name) private readonly categoryModel: Model<CategoryDocument>,
+    @InjectModel(PaymentSource.name) private readonly paymentSourceModel: Model<PaymentSourceDocument>,
+    @InjectModel(UserConfig.name) private readonly userConfigModel: Model<UserConfigDocument>,
+  ) {}
+
+  async parseReceipt(params: ReceiptParseParams): Promise<ReceiptParseResult> {
+    const apiKey = this.configService.get<string>('GEMINI_API_KEY');
+
+    if (!apiKey) {
+      this.logger.error('Missing GEMINI_API_KEY environment variable.');
+      throw new InternalServerErrorException('Gemini API key is not configured');
+    }
+
+    const { image, userId } = params;
+
+    this.ensureValidImage(image);
+
+    const [categories, paymentSources, preferredCurrency] = await Promise.all([
+      this.fetchCategories(userId),
+      this.fetchPaymentSources(userId),
+      this.fetchPreferredCurrency(userId),
+    ]);
+
+    this.ensureRequiredData(categories, paymentSources);
+
+    const base64Image = image.buffer.toString('base64');
+
+    let lastJsonError: Error | null = null;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      const prompt = this.buildPrompt(categories, paymentSources, preferredCurrency, attempt);
+
+      let responseData: Record<string, unknown>;
+
+      try {
+        const response = await firstValueFrom(
+          this.httpService.post(
+            this.endpoint,
+            {
+              contents: [
+                {
+                  role: 'user',
+                  parts: [
+                    {
+                      inline_data: {
+                        mime_type: image.mimetype,
+                        data: base64Image,
+                      },
+                    },
+                    {
+                      text: prompt,
+                    },
+                  ],
+                },
+              ],
+              generationConfig: {
+                responseMimeType: 'application/json',
+                temperature: 0.1,
+              },
+            },
+            {
+              headers: {
+                'Content-Type': 'application/json',
+                'x-goog-api-key': apiKey,
+              },
+              timeout: 20000,
+            },
+          ),
+        );
+
+        responseData = response?.data as Record<string, unknown>;
+      } catch (err) {
+        const error = err as { response?: { status?: number; data?: unknown } };
+        this.logger.error(`Gemini API request failed`, error);
+
+        if (error.response?.status === 401 || error.response?.status === 403) {
+          throw new InternalServerErrorException('Gemini API rejected the request. Check API key and quota.');
+        }
+
+        throw new UnprocessableEntityException('Не удалось распознать чек');
+      }
+
+      const candidateText = this.extractCandidateText(responseData);
+      const parsed = this.tryParseGeminiJson(candidateText);
+
+      if (!parsed) {
+        lastJsonError = new Error('JSON_PARSE_ERROR');
+        this.logger.warn(`Gemini response was not valid JSON (attempt ${attempt}).`);
+        continue;
+      }
+
+      if (typeof parsed.recognized !== 'boolean') {
+        lastJsonError = new Error('JSON_STRUCTURE_ERROR');
+        this.logger.warn(`Gemini JSON missing required "recognized" field (attempt ${attempt}).`);
+        continue;
+      }
+
+      if (!parsed.recognized) {
+        throw new UnprocessableEntityException(parsed.reason || 'Чек не распознан моделью');
+      }
+
+      if (!parsed.expense) {
+        throw new UnprocessableEntityException('Модель не вернула данные о трате');
+      }
+
+      const expenseInput = this.normalizeExpenseInput(parsed.expense, categories, paymentSources, preferredCurrency);
+
+      return {
+        expenseInput,
+        reason: parsed.reason ?? null,
+      };
+    }
+
+    if (lastJsonError) {
+      throw new UnprocessableEntityException('Модель вернула некорректный JSON');
+    }
+
+    throw new UnprocessableEntityException('Не удалось распознать чек');
+  }
+
+  private ensureValidImage(image: Express.Multer.File | undefined) {
+    if (!image) {
+      throw new BadRequestException('Необходимо загрузить фотографию чека');
+    }
+
+    if (!this.supportedMimeTypes.has(image.mimetype)) {
+      throw new BadRequestException('Поддерживаются только изображения JPEG, PNG или WEBP');
+    }
+  }
+
+  private ensureRequiredData(categories: ReceiptOption[], paymentSources: ReceiptOption[]) {
+    if (!categories.length) {
+      throw new UnprocessableEntityException('Для пользователя не найдены категории трат');
+    }
+
+    if (!paymentSources.length) {
+      throw new UnprocessableEntityException('Для пользователя не найдены источники трат');
+    }
+  }
+
+  private async fetchCategories(userId: string): Promise<ReceiptOption[]> {
+    const results = await this.categoryModel.find({ userId }).select('_id title').lean();
+
+    return results.map((doc) => ({
+      id: doc._id.toString(),
+      name: doc.title,
+    }));
+  }
+
+  private async fetchPaymentSources(userId: string): Promise<ReceiptOption[]> {
+    const results = await this.paymentSourceModel.find({ userId }).select('_id title').lean();
+
+    return results.map((doc) => ({
+      id: doc._id.toString(),
+      name: doc.title,
+    }));
+  }
+
+  private async fetchPreferredCurrency(userId: string): Promise<string | null> {
+    const config = await this.userConfigModel.findOne({ userId }).select('currency').lean();
+
+    if (!config?.currency) {
+      return null;
+    }
+
+    return config.currency.toString().trim().toUpperCase();
+  }
+
+  private buildPrompt(
+    categories: ReceiptOption[],
+    paymentSources: ReceiptOption[],
+    preferredCurrency: string | null | undefined,
+    attempt: number,
+  ): string {
+    const categoriesJson = JSON.stringify(categories, null, 2);
+    const paymentSourcesJson = JSON.stringify(paymentSources, null, 2);
+    const fallbackCurrencyInstruction = preferredCurrency
+      ? `If the receipt does not explicitly show the currency even after carefully checking symbols and wording, default to "${preferredCurrency}".`
+      : 'If the receipt does not explicitly show the currency even after carefully checking symbols and wording, leave it null.';
+
+    const attemptReminder =
+      attempt > 1
+        ? `\nATTEMPT ${attempt}: Previous response was not valid JSON. Return ONLY raw JSON with no Markdown, no commentary.`
+        : '';
+
+    return [
+      'You are a financial assistant that extracts expense data from receipt photos.',
+      'Use only categoryId and paymentSourceId from the provided lists when preparing the expense.',
+      'If anything is unreadable set recognized to false and explain why.',
+      'Currency detection is critical: scan the receipt for currency codes (e.g., USD, EUR, KZT), symbols ($, €, ₸, ₴, ₸, ₺, ₽), and localized words (e.g., тенге, доллар, евро).',
+      'If the currency is still unclear, use the language of the receipt as a hint (e.g., Turkish text often implies TRY, Kazakh text mentioning “тенге” implies KZT, Russian text without explicit symbols implies RUB, most European languages imply EUR).',
+      'If multiple currencies appear, choose the one attached to the final total. Always output the currency as a three-letter ISO code in uppercase.',
+      'Map common symbols to ISO codes: $ -> USD unless otherwise stated, ₸ -> KZT, ₴ -> UAH, ₽ -> RUB, ₺ -> TRY, € -> EUR, £ -> GBP.',
+      'If the total amount contains a trailing currency symbol or word (e.g., "4500 ₸", "4500 тенге"), use that currency.',
+      '',
+      `Categories JSON:\n${categoriesJson}`,
+      '',
+      `Payment sources JSON:\n${paymentSourcesJson}`,
+      '',
+      fallbackCurrencyInstruction,
+      '',
+      'Ensure the amount represents the final total to pay (use dot as decimal separator).',
+      'Prefer the purchase date/time from the receipt; fallback to today if missing.',
+      'RESPONSE FORMAT:',
+      'Return ONLY raw JSON with the following structure:',
+      '{',
+      '  "recognized": boolean,',
+      '  "reason": string | null,',
+      '  "expense": {',
+      '    "amount": number | string,',
+      '    "currency": string | null,',
+      '    "categoryId": string,',
+      '    "paymentSourceId": string,',
+      '    "comments": string | null,',
+      '    "createdAt": string | null',
+      '  }',
+      '}',
+      '',
+      'Do not include Markdown fences, backticks, explanations, or additional text outside the JSON object.',
+      attemptReminder,
+    ].join('\n');
+  }
+
+  private extractCandidateText(data: unknown): string {
+    if (!data || typeof data !== 'object') {
+      throw new UnprocessableEntityException('Не удалось обработать ответ модели');
+    }
+
+    const candidates = (data as Record<string, unknown>).candidates as unknown[];
+
+    if (!Array.isArray(candidates) || !candidates.length) {
+      throw new UnprocessableEntityException('Модель не вернула кандидатов');
+    }
+
+    const parts = (candidates[0] as Record<string, unknown>)?.content as Record<string, unknown>;
+    const firstPart = Array.isArray(parts?.parts) ? parts.parts[0] : undefined;
+
+    const text = firstPart && typeof firstPart === 'object' ? (firstPart as Record<string, unknown>).text : undefined;
+
+    if (typeof text !== 'string' || !text.trim()) {
+      throw new UnprocessableEntityException('Модель не вернула текстовый ответ');
+    }
+
+    return text.trim();
+  }
+
+  private tryParseGeminiJson(raw: string): GeminiExpenseResponse | null {
+    const sanitized = raw
+      .replace(/```json/gi, '')
+      .replace(/```/g, '')
+      .trim();
+
+    try {
+      return JSON.parse(sanitized) as GeminiExpenseResponse;
+    } catch (error) {
+      this.logger.debug(`Failed to parse Gemini JSON response`, error as Error);
+
+      return null;
+    }
+  }
+
+  private normalizeExpenseInput(
+    expense: NonNullable<GeminiExpenseResponse['expense']>,
+    categories: ReceiptOption[],
+    paymentSources: ReceiptOption[],
+    preferredCurrency: string | null,
+  ): ExpenseInputDto {
+    const amount = this.toNumber(expense.amount);
+
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new UnprocessableEntityException('Модель вернула некорректную сумму');
+    }
+
+    const categoryId = this.validateOption('categoryId', expense.categoryId, categories);
+    const paymentSourceId = this.validateOption('paymentSourceId', expense.paymentSourceId, paymentSources);
+
+    const currency = this.resolveCurrency(expense.currency, preferredCurrency);
+    const createdAt = this.normalizeDate(expense.createdAt);
+    const comments = this.normalizeComment(expense.comments);
+
+    return {
+      amount,
+      categoryId,
+      paymentSourceId,
+      currency,
+      comments,
+      createdAt,
+    } as ExpenseInputDto;
+  }
+
+  private validateOption(
+    field: 'categoryId' | 'paymentSourceId',
+    value: string | undefined,
+    options: ReceiptOption[],
+  ): string {
+    if (!value) {
+      throw new UnprocessableEntityException(
+        `Модель не выбрала ${field === 'categoryId' ? 'категорию' : 'источник оплаты'}`,
+      );
+    }
+
+    const matched = options.find((option) => option.id === value);
+
+    if (!matched) {
+      throw new UnprocessableEntityException(`Модель вернула неизвестный идентификатор в поле ${field}`);
+    }
+
+    return matched.id;
+  }
+
+  private resolveCurrency(modelCurrency: string | null | undefined, preferredCurrency: string | null): CURRENCIES {
+    const candidates = [modelCurrency, preferredCurrency, CURRENCIES.USD].filter(
+      (value): value is string => typeof value === 'string' && Boolean(value.trim()),
+    );
+
+    for (const candidate of candidates) {
+      const normalized = candidate.trim().toUpperCase();
+
+      if (this.isSupportedCurrency(normalized)) {
+        return normalized as CURRENCIES;
+      }
+    }
+
+    return CURRENCIES.USD;
+  }
+
+  private normalizeDate(value?: string | null): Date {
+    if (!value) {
+      return new Date();
+    }
+
+    const parsed = new Date(value);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return new Date();
+    }
+
+    return parsed;
+  }
+
+  private normalizeComment(value?: string | null): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const trimmed = value.toString().trim();
+
+    if (!trimmed) {
+      return undefined;
+    }
+
+    return trimmed.slice(0, 100);
+  }
+
+  private toNumber(value: number | string | undefined): number {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const normalized = value.replace(',', '.').trim();
+      const parsed = Number.parseFloat(normalized);
+
+      return Number.isFinite(parsed) ? parsed : NaN;
+    }
+
+    return NaN;
+  }
+
+  private isSupportedCurrency(value: string): boolean {
+    return (Object.values(CURRENCIES) as string[]).includes(value);
+  }
+}

--- a/src/app/expense/receipt-ai.service.ts
+++ b/src/app/expense/receipt-ai.service.ts
@@ -245,7 +245,7 @@ export class ReceiptAiService {
       'You are a financial assistant that extracts expense data from receipt photos.',
       'Use only categoryId and paymentSourceId from the provided lists when preparing the expense.',
       'If anything is unreadable set recognized to false and explain why.',
-      'Currency detection is critical: scan the receipt for currency codes (e.g., USD, EUR, KZT), symbols ($, €, ₸, ₴, ₸, ₺, ₽), and localized words (e.g., тенге, доллар, евро).',
+      'Currency detection is critical: scan the receipt for currency codes (e.g., USD, EUR, KZT), symbols ($, €, ₸, ₴, ₺, ₽), and localized words (e.g., тенге, доллар, евро).',
       'If the currency is still unclear, use the language of the receipt as a hint (e.g., Turkish text often implies TRY, Kazakh text mentioning “тенге” implies KZT, Russian text without explicit symbols implies RUB, most European languages imply EUR).',
       'If multiple currencies appear, choose the one attached to the final total. Always output the currency as a three-letter ISO code in uppercase.',
       'Map common symbols to ISO codes: $ -> USD unless otherwise stated, ₸ -> KZT, ₴ -> UAH, ₽ -> RUB, ₺ -> TRY, € -> EUR, £ -> GBP.',


### PR DESCRIPTION
 - enhance the receipt parsing service to retry prompt-based Gemini calls, tighten currency
    extraction guidance, and normalize the returned data directly into saved expenses
  - centralize receipt-AI error codes, timeouts, and comment limits for localization and
    maintainability, while masking sensitive details in logs
  - wire Gemini API secrets into preview/production workflows so builds have the required key