### PR TITLE
Аналитика расходов

### DIFF
--- a/src/app/expense/decorators/get-expense-analytics-sw.decorator.ts
+++ b/src/app/expense/decorators/get-expense-analytics-sw.decorator.ts
@@ -1,0 +1,98 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ExpenseAnalyticsResponseDto } from '../dto/expense-analytics-response.dto';
+import { AnalyticsTrendGranularity } from '../dto/expense-analytics-query.dto';
+import { CURRENCIES } from '../../../common/interfaces/currencies.enum';
+
+export function GetExpenseAnalyticsSwDec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Получить агрегированную аналитику по расходам с гибкими фильтрами и AI-инсайтами',
+      description: `
+        Возвращает агрегированные показатели по расходам, разбивки по категориям, источникам и динамику во времени.
+        По умолчанию анализируется текущий месяц. Можно включить AI-описание.
+      `,
+    }),
+    ApiBearerAuth(),
+    ApiQuery({
+      name: 'createdStartDate',
+      required: false,
+      type: String,
+      description: 'Начальная дата (ISO). По умолчанию — первый день текущего месяца (UTC).',
+    }),
+    ApiQuery({
+      name: 'createdEndDate',
+      required: false,
+      type: String,
+      description: 'Конечная дата (ISO). По умолчанию — текущий момент (UTC).',
+    }),
+    ApiQuery({
+      name: 'categoryIds',
+      required: false,
+      isArray: true,
+      type: String,
+      description: 'Список ID категорий для фильтрации (через массив или через запятую).',
+    }),
+    ApiQuery({
+      name: 'paymentSourceIds',
+      required: false,
+      isArray: true,
+      type: String,
+      description: 'Список ID источников оплаты для фильтрации (через массив или через запятую).',
+    }),
+    ApiQuery({
+      name: 'currencies',
+      required: false,
+      isArray: true,
+      enum: CURRENCIES,
+      description: 'Ограничить выборку исходными валютами расходов.',
+    }),
+    ApiQuery({
+      name: 'amountStart',
+      required: false,
+      type: Number,
+      description: 'Минимальная сумма транзакции (в исходной валюте записи).',
+    }),
+    ApiQuery({
+      name: 'amountEnd',
+      required: false,
+      type: Number,
+      description: 'Максимальная сумма транзакции (в исходной валюте записи).',
+    }),
+    ApiQuery({
+      name: 'targetCurrency',
+      required: false,
+      enum: CURRENCIES,
+      description: 'Валюта, в которой возвращаются агрегаты. По умолчанию — валюта профиля или USD.',
+    }),
+    ApiQuery({
+      name: 'hasComments',
+      required: false,
+      type: Boolean,
+      description: 'true — только расходы с комментариями, false — только без комментариев.',
+    }),
+    ApiQuery({
+      name: 'searchTerm',
+      required: false,
+      type: String,
+      description: 'Поиск по комментариям (регистронезависимый).',
+    }),
+    ApiQuery({
+      name: 'trendGranularity',
+      required: false,
+      enum: AnalyticsTrendGranularity,
+      description: 'Шаг агрегации для динамики: day, week, month, year. По умолчанию — month.',
+    }),
+    ApiQuery({
+      name: 'includeAiAnalysis',
+      required: false,
+      type: Boolean,
+      description: 'Включить генерацию компактного AI-анализа (требует сконфигурированный GEMINI_API_KEY).',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Агрегированная статистика по расходам.',
+      type: ExpenseAnalyticsResponseDto,
+    }),
+  );
+}

--- a/src/app/expense/dto/expense-analytics-query.dto.ts
+++ b/src/app/expense/dto/expense-analytics-query.dto.ts
@@ -1,0 +1,136 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsArray, IsBoolean, IsEnum, IsIn, IsMongoId, IsOptional, IsString } from 'class-validator';
+import { ExpenseQueryInputDto } from './expense-query-input.dto';
+import { CURRENCIES } from '../../../common/interfaces/currencies.enum';
+
+const toArray = (value: unknown): string[] | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === 'string' ? item.trim() : String(item)))
+      .filter((item) => item.length > 0);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+
+  return [String(value)];
+};
+
+const toBoolean = (value: unknown): boolean | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (['true', '1', 'yes', 'y'].includes(normalized)) {
+      return true;
+    }
+
+    if (['false', '0', 'no', 'n'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return undefined;
+};
+
+export enum AnalyticsTrendGranularity {
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+  YEAR = 'year',
+}
+
+export class ExpenseAnalyticsQueryDto extends ExpenseQueryInputDto {
+  @ApiPropertyOptional({
+    description: 'Filter expenses by multiple category IDs',
+    type: [String],
+    example: ['6616f96da226986482597b6c'],
+  })
+  @IsOptional()
+  @IsMongoId({ each: true })
+  @Transform(({ value }) => toArray(value))
+  categoryIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter expenses by multiple payment source IDs',
+    type: [String],
+    example: ['6616f96da226986482597b6c'],
+  })
+  @IsOptional()
+  @IsMongoId({ each: true })
+  @Transform(({ value }) => toArray(value))
+  paymentSourceIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter expenses by source currencies',
+    type: [String],
+    enum: CURRENCIES,
+    isArray: true,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(CURRENCIES, { each: true })
+  @Transform(({ value }) => toArray(value)?.map((item) => item.toUpperCase()))
+  currencies?: CURRENCIES[];
+
+  @ApiPropertyOptional({
+    description: 'Desired currency for the aggregated amounts',
+    enum: CURRENCIES,
+    example: CURRENCIES.USD,
+  })
+  @IsOptional()
+  @IsEnum(CURRENCIES)
+  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
+  targetCurrency?: CURRENCIES;
+
+  @ApiPropertyOptional({
+    description: 'Whether to include only expenses that contain comments',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => toBoolean(value))
+  hasComments?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Perform a case-insensitive search within comments',
+    example: 'подписка',
+  })
+  @IsOptional()
+  @IsString()
+  searchTerm?: string;
+
+  @ApiPropertyOptional({
+    description: 'Controls the granularity of the time trend data',
+    enum: AnalyticsTrendGranularity,
+    example: AnalyticsTrendGranularity.MONTH,
+  })
+  @IsOptional()
+  @IsIn(Object.values(AnalyticsTrendGranularity))
+  trendGranularity?: AnalyticsTrendGranularity;
+
+  @ApiPropertyOptional({
+    description: 'Include AI generated insights based on the aggregated data',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => toBoolean(value))
+  includeAiAnalysis?: boolean;
+}

--- a/src/app/expense/dto/expense-analytics-response.dto.ts
+++ b/src/app/expense/dto/expense-analytics-response.dto.ts
@@ -1,0 +1,220 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CURRENCIES } from '../../../common/interfaces/currencies.enum';
+import { AnalyticsTrendGranularity } from './expense-analytics-query.dto';
+
+export class ExpenseAnalyticsSummaryDto {
+  @ApiProperty({
+    description: 'Total amount of expenses within the applied filters in the target currency',
+    example: 1250.42,
+  })
+  totalAmount: number;
+
+  @ApiProperty({
+    description: 'Number of expenses matched by the filters',
+    example: 42,
+  })
+  totalCount: number;
+
+  @ApiProperty({
+    description: 'Average expense amount in the target currency',
+    example: 29.77,
+  })
+  averageAmount: number;
+
+  @ApiProperty({
+    description: 'Minimum expense amount in the target currency',
+    example: 5.3,
+  })
+  minAmount: number;
+
+  @ApiProperty({
+    description: 'Maximum expense amount in the target currency',
+    example: 480.9,
+  })
+  maxAmount: number;
+
+  @ApiProperty({
+    description: 'Currency used for the aggregated values',
+    enum: CURRENCIES,
+    example: CURRENCIES.USD,
+  })
+  currency: CURRENCIES;
+}
+
+export class ExpenseAnalyticsBreakdownItemDto {
+  @ApiProperty({
+    description: 'Identifier of the category or payment source',
+    example: '6616f96da226986482597b6c',
+  })
+  id: string;
+
+  @ApiPropertyOptional({
+    description: 'Resolved name of the entity (if available)',
+    example: 'Продукты',
+    type: String,
+    nullable: true,
+  })
+  name?: string | null;
+
+  @ApiProperty({
+    description: 'Total amount spent for the given entity in the target currency',
+    example: 430.75,
+  })
+  totalAmount: number;
+
+  @ApiProperty({
+    description: 'Percentage share of the entity relative to the total amount',
+    example: 34.5,
+  })
+  percentage: number;
+
+  @ApiProperty({
+    description: 'Number of expenses attributed to the entity',
+    example: 12,
+  })
+  count: number;
+}
+
+export class ExpenseAnalyticsTrendPointDto {
+  @ApiProperty({
+    description: 'Time period label constructed using the requested granularity',
+    example: '2024-06',
+  })
+  period: string;
+
+  @ApiProperty({
+    description: 'Aggregated amount for the time period in the target currency',
+    example: 215.6,
+  })
+  totalAmount: number;
+
+  @ApiProperty({
+    description: 'Average expense amount inside the period',
+    example: 26.95,
+  })
+  averageAmount: number;
+
+  @ApiProperty({
+    description: 'Number of expenses within the period',
+    example: 8,
+  })
+  count: number;
+}
+
+export class ExpenseAnalyticsAppliedFiltersDto {
+  @ApiPropertyOptional({
+    description: 'Category filters applied during aggregation',
+    type: [String],
+  })
+  categoryIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Payment source filters applied during aggregation',
+    type: [String],
+  })
+  paymentSourceIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Original currencies included in the dataset',
+    type: [String],
+    enum: CURRENCIES,
+  })
+  currencies?: CURRENCIES[];
+
+  @ApiPropertyOptional({
+    description: 'Date range start used for the dataset (ISO string)',
+    example: '2024-05-01T00:00:00.000Z',
+    nullable: true,
+  })
+  createdStartDate?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Date range end used for the dataset (ISO string)',
+    example: '2024-05-31T23:59:59.999Z',
+    nullable: true,
+  })
+  createdEndDate?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Lower bound for expense amount filtering in original currency',
+    example: 10,
+    nullable: true,
+  })
+  amountStart?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Upper bound for expense amount filtering in original currency',
+    example: 500,
+    nullable: true,
+  })
+  amountEnd?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Indicates whether the dataset is limited to expenses with comments',
+    example: true,
+    nullable: true,
+  })
+  hasComments?: boolean | null;
+
+  @ApiPropertyOptional({
+    description: 'Search term that was applied to comments',
+    example: 'подписка',
+    nullable: true,
+  })
+  searchTerm?: string | null;
+
+  @ApiProperty({
+    description: 'Granularity used to build the trend timeline',
+    enum: AnalyticsTrendGranularity,
+    example: AnalyticsTrendGranularity.MONTH,
+  })
+  trendGranularity: AnalyticsTrendGranularity;
+
+  @ApiProperty({
+    description: 'Currency used for aggregated values',
+    enum: CURRENCIES,
+    example: CURRENCIES.USD,
+  })
+  targetCurrency: CURRENCIES;
+}
+
+export class ExpenseAnalyticsAiInsightDto {
+  @ApiProperty({
+    description: 'Textual AI generated insight derived from the aggregated data',
+    example: '- Самая большая доля расходов пришлась на категорию «Продукты» (35%).',
+  })
+  summary: string;
+
+  @ApiProperty({
+    description: 'Timestamp when the insight was generated',
+    example: '2024-06-20T10:15:30.000Z',
+  })
+  generatedAt: string;
+
+  @ApiPropertyOptional({
+    description: 'Model identifier that produced the insight',
+    example: 'gemini-2.0-flash-001',
+    nullable: true,
+  })
+  model?: string | null;
+}
+
+export class ExpenseAnalyticsResponseDto {
+  @ApiProperty({ type: ExpenseAnalyticsSummaryDto })
+  summary: ExpenseAnalyticsSummaryDto;
+
+  @ApiProperty({ type: ExpenseAnalyticsBreakdownItemDto, isArray: true })
+  byCategory: ExpenseAnalyticsBreakdownItemDto[];
+
+  @ApiProperty({ type: ExpenseAnalyticsBreakdownItemDto, isArray: true })
+  byPaymentSource: ExpenseAnalyticsBreakdownItemDto[];
+
+  @ApiProperty({ type: ExpenseAnalyticsTrendPointDto, isArray: true })
+  trend: ExpenseAnalyticsTrendPointDto[];
+
+  @ApiProperty({ type: ExpenseAnalyticsAppliedFiltersDto })
+  appliedFilters: ExpenseAnalyticsAppliedFiltersDto;
+
+  @ApiPropertyOptional({ type: ExpenseAnalyticsAiInsightDto })
+  aiInsights?: ExpenseAnalyticsAiInsightDto;
+}

--- a/src/app/expense/expense-analytics.controller.spec.ts
+++ b/src/app/expense/expense-analytics.controller.spec.ts
@@ -1,0 +1,203 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { Connection, Types } from 'mongoose';
+import * as request from 'supertest';
+import { cleanupTestApp, setupTestApp } from '../../../test/test-utils';
+import { CURRENCIES } from '../../common/interfaces/currencies.enum';
+
+describe('Expense Analytics (e2e)', () => {
+  let app: INestApplication;
+  let connection: Connection;
+  let jwtService: JwtService;
+  let configService: ConfigService;
+
+  beforeAll(async () => {
+    const testSetup = await setupTestApp();
+    app = testSetup.app;
+    connection = testSetup.connection;
+    jwtService = app.get(JwtService);
+    configService = app.get(ConfigService);
+  });
+
+  afterAll(async () => {
+    await cleanupTestApp(app, connection);
+  });
+
+  it('returns aggregated analytics for current month with default filters', async () => {
+    const collections = ['Expenses', 'Category', 'PaymentSource', 'User', 'UserConfig'];
+
+    for (const name of collections) {
+      await connection.collection(name).deleteMany({});
+    }
+
+    const userObjectId = new Types.ObjectId();
+    const userId = userObjectId.toHexString();
+    const userEmail = 'analytics@example.com';
+
+    await connection.collection('User').insertOne({
+      _id: userObjectId,
+      email: userEmail,
+      login: 'analytics',
+      passwordHash: 'hashed-password',
+      isVerified: true,
+    });
+
+    await connection.collection('UserConfig').insertOne({
+      _id: new Types.ObjectId(),
+      userId,
+      theme: 'light',
+      currency: CURRENCIES.USD,
+      language: 'ru',
+      showCategoryNames: true,
+      showSourceNames: true,
+      showSharedExpenses: true,
+      showSharedCategories: true,
+      showSharedSources: true,
+      showCategoryColours: true,
+      showSourceColours: true,
+    });
+
+    const categoryFoodId = new Types.ObjectId();
+    const categoryFunId = new Types.ObjectId();
+
+    await connection.collection('Category').insertMany([
+      { _id: categoryFoodId, title: 'Еда', userId, order: 1 },
+      { _id: categoryFunId, title: 'Развлечения', userId, order: 2 },
+    ]);
+
+    const paymentCardId = new Types.ObjectId();
+    const paymentCashId = new Types.ObjectId();
+
+    await connection.collection('PaymentSource').insertMany([
+      { _id: paymentCardId, title: 'Карта', userId, order: 1 },
+      { _id: paymentCashId, title: 'Наличные', userId, order: 2 },
+    ]);
+
+    const now = new Date();
+    const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+    const spanWithinMonth = Math.max(now.getTime() - startOfMonth.getTime(), 3 * 60 * 60 * 1000);
+    const step = Math.max(Math.floor(spanWithinMonth / 3), 1);
+    const withinMonthTimestamp = new Date(startOfMonth.getTime() + step);
+    const earlierWithinMonth = new Date(startOfMonth.getTime() + step * 2);
+    const earliestWithinMonth = new Date(startOfMonth.getTime() + step * 3);
+    const expenses = [
+      {
+        _id: new Types.ObjectId(),
+        userId,
+        amount: 50,
+        categoryId: categoryFoodId.toHexString(),
+        paymentSourceId: paymentCardId.toHexString(),
+        currency: CURRENCIES.USD,
+        exchangeRates: { USD: 1 },
+        comments: 'Продукты',
+        createdAt: withinMonthTimestamp,
+        updatedAt: withinMonthTimestamp,
+      },
+      {
+        _id: new Types.ObjectId(),
+        userId,
+        amount: 75,
+        categoryId: categoryFoodId.toHexString(),
+        paymentSourceId: paymentCashId.toHexString(),
+        currency: CURRENCIES.USD,
+        exchangeRates: { USD: 1 },
+        comments: 'Ужин',
+        createdAt: earlierWithinMonth,
+        updatedAt: earlierWithinMonth,
+      },
+      {
+        _id: new Types.ObjectId(),
+        userId,
+        amount: 25,
+        categoryId: categoryFunId.toHexString(),
+        paymentSourceId: paymentCardId.toHexString(),
+        currency: CURRENCIES.USD,
+        exchangeRates: { USD: 1 },
+        comments: 'Кино',
+        createdAt: earliestWithinMonth,
+        updatedAt: earliestWithinMonth,
+      },
+    ];
+
+    await connection.collection('Expenses').insertMany(expenses);
+
+    const accessToken = await jwtService.signAsync(
+      {
+        userId,
+        email: userEmail,
+        isVerified: true,
+      },
+      {
+        secret: configService.get<string>('ACCESS_TOKEN_KEY'),
+      },
+    );
+
+    const response = await request(app.getHttpServer())
+      .get('/api/expense/analytics')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(response.body.summary).toMatchObject({
+      totalAmount: 150,
+      totalCount: 3,
+      averageAmount: 50,
+      minAmount: 25,
+      maxAmount: 75,
+      currency: CURRENCIES.USD,
+    });
+
+    expect(response.body.byCategory).toEqual([
+      {
+        id: categoryFoodId.toHexString(),
+        name: 'Еда',
+        totalAmount: 125,
+        percentage: 83.33,
+        count: 2,
+      },
+      {
+        id: categoryFunId.toHexString(),
+        name: 'Развлечения',
+        totalAmount: 25,
+        percentage: 16.67,
+        count: 1,
+      },
+    ]);
+
+    expect(response.body.byPaymentSource).toHaveLength(2);
+    expect(response.body.byPaymentSource).toEqual(
+      expect.arrayContaining([
+        {
+          id: paymentCardId.toHexString(),
+          name: 'Карта',
+          totalAmount: 75,
+          percentage: 50,
+          count: 2,
+        },
+        {
+          id: paymentCashId.toHexString(),
+          name: 'Наличные',
+          totalAmount: 75,
+          percentage: 50,
+          count: 1,
+        },
+      ]),
+    );
+
+    expect(response.body.trend).toHaveLength(1);
+    expect(response.body.trend[0]).toMatchObject({
+      period: startOfMonth.toISOString().slice(0, 7),
+      totalAmount: 150,
+      averageAmount: 50,
+      count: 3,
+    });
+
+    const startOfMonthUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
+    expect(response.body.appliedFilters.targetCurrency).toBe(CURRENCIES.USD);
+    expect(response.body.appliedFilters.trendGranularity).toBe('month');
+    expect(response.body.appliedFilters.createdStartDate).toBe(startOfMonthUtc);
+    expect(new Date(response.body.appliedFilters.createdEndDate).getTime()).toBeGreaterThanOrEqual(
+      expenses[0].createdAt.getTime(),
+    );
+  });
+});

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -18,6 +18,167 @@ import {
   ExpenseAnalyticsTrendPointDto,
 } from './dto/expense-analytics-response.dto';
 import { CURRENCIES } from '../../common/interfaces/currencies.enum';
+import { LANGUAGES } from '../../common/interfaces/languages.enum';
+
+type PromptLocale = {
+  intro: string;
+  task: string;
+  format: string;
+  currencyHeadline: (currency: CURRENCIES) => string;
+  metrics: {
+    totalAmount: string;
+    totalCount: string;
+    average: string;
+    min: string;
+    max: string;
+  };
+  categoriesTitle: string;
+  categoriesFallback: string;
+  sourcesTitle: string;
+  sourcesFallback: string;
+  trendTitle: string;
+  trendFallback: string;
+  breakdownLine: (
+    index: number,
+    name: string,
+    amount: string,
+    percentage: string,
+    count: number,
+    currency: CURRENCIES,
+    type: 'category' | 'source',
+  ) => string;
+  trendLine: (period: string, total: string, average: string, count: number, currency: CURRENCIES) => string;
+  unnamed: string;
+  finalInstruction: string;
+};
+
+const PROMPT_LOCALES: Record<LANGUAGES, PromptLocale> = {
+  [LANGUAGES.RU]: {
+    intro: 'Ты — дружелюбный персональный финансовый аналитик.',
+    task: 'По аггрегированным данным ниже сделай 3-4 практичных наблюдения и сформулируй 1 рекомендацию.',
+    format: 'Пиши по-русски, лаконично, маркированными пунктами (каждый пункт начинай с "- ").',
+    currencyHeadline: (currency) => `Данные в валюте ${currency}:`,
+    metrics: {
+      totalAmount: '• Общая сумма',
+      totalCount: '• Количество операций',
+      average: '• Средний чек',
+      min: '• Минимальный чек',
+      max: '• Максимальный чек',
+    },
+    categoriesTitle: 'Категории (топ 5):',
+    categoriesFallback: 'Категории: нет данных.',
+    sourcesTitle: 'Источники оплаты (топ 5):',
+    sourcesFallback: 'Источники оплаты: нет данных.',
+    trendTitle: 'Динамика:',
+    trendFallback: 'Динамика: нет данных.',
+    breakdownLine: (index, name, amount, percentage, count, currency) =>
+      `${index + 1}. ${name} — ${amount} ${currency} (${percentage}%), операций: ${count}`,
+    trendLine: (period, total, average, count, currency) =>
+      `${period}: сумма ${total} ${currency}, средний чек ${average}, операций ${count}`,
+    unnamed: 'Без названия',
+    finalInstruction: 'Избегай общих фраз, делай конкретные выводы и предложи понятный следующий шаг.',
+  },
+  [LANGUAGES.EN]: {
+    intro: 'You are a friendly personal finance analyst.',
+    task: 'Using the aggregated data below, share 3-4 practical observations and provide 1 actionable recommendation.',
+    format: 'Respond in English with concise bullet points (each line starts with "- ").',
+    currencyHeadline: (currency) => `Figures in ${currency}:`,
+    metrics: {
+      totalAmount: '• Total amount',
+      totalCount: '• Number of transactions',
+      average: '• Average ticket',
+      min: '• Minimum ticket',
+      max: '• Maximum ticket',
+    },
+    categoriesTitle: 'Categories (top 5):',
+    categoriesFallback: 'Categories: no data.',
+    sourcesTitle: 'Payment sources (top 5):',
+    sourcesFallback: 'Payment sources: no data.',
+    trendTitle: 'Trend:',
+    trendFallback: 'Trend: no data.',
+    breakdownLine: (index, name, amount, percentage, count, currency) =>
+      `${index + 1}. ${name} — ${amount} ${currency} (${percentage}%), transactions: ${count}`,
+    trendLine: (period, total, average, count, currency) =>
+      `${period}: total ${total} ${currency}, average ${average}, transactions ${count}`,
+    unnamed: 'Unnamed',
+    finalInstruction: 'Stay specific, avoid generic statements, and close with a clear next step.',
+  },
+  [LANGUAGES.DE]: {
+    intro: 'Du bist ein freundlicher Finanzanalyst.',
+    task: 'Analysiere die Daten und formuliere 3-4 praxisnahe Beobachtungen sowie eine konkrete Empfehlung.',
+    format: 'Antworte auf Deutsch in knappen Stichpunkten (jede Zeile beginnt mit "- ").',
+    currencyHeadline: (currency) => `Kennzahlen in ${currency}:`,
+    metrics: {
+      totalAmount: '• Gesamtsumme',
+      totalCount: '• Anzahl Buchungen',
+      average: '• Durchschnittlicher Betrag',
+      min: '• Minimaler Betrag',
+      max: '• Maximaler Betrag',
+    },
+    categoriesTitle: 'Kategorien (Top 5):',
+    categoriesFallback: 'Kategorien: keine Daten.',
+    sourcesTitle: 'Zahlungsquellen (Top 5):',
+    sourcesFallback: 'Zahlungsquellen: keine Daten.',
+    trendTitle: 'Verlauf:',
+    trendFallback: 'Verlauf: keine Daten.',
+    breakdownLine: (index, name, amount, percentage, count, currency) =>
+      `${index + 1}. ${name} — ${amount} ${currency} (${percentage}%), Buchungen: ${count}`,
+    trendLine: (period, total, average, count, currency) =>
+      `${period}: Gesamt ${total} ${currency}, Durchschnitt ${average}, Buchungen ${count}`,
+    unnamed: 'Ohne Titel',
+    finalInstruction: 'Vermeide Allgemeinplätze, liefere konkrete Einsichten und einen klaren nächsten Schritt.',
+  },
+  [LANGUAGES.ES]: {
+    intro: 'Eres un analista financiero cercano y útil.',
+    task: 'Con los datos agregados, ofrece 3-4 observaciones prácticas y una recomendación accionable.',
+    format: 'Responde en español con puntos breves (cada línea empieza con "- ").',
+    currencyHeadline: (currency) => `Cifras en ${currency}:`,
+    metrics: {
+      totalAmount: '• Importe total',
+      totalCount: '• Número de operaciones',
+      average: '• Ticket medio',
+      min: '• Ticket mínimo',
+      max: '• Ticket máximo',
+    },
+    categoriesTitle: 'Categorías (top 5):',
+    categoriesFallback: 'Categorías: sin datos.',
+    sourcesTitle: 'Fuentes de pago (top 5):',
+    sourcesFallback: 'Fuentes de pago: sin datos.',
+    trendTitle: 'Tendencia:',
+    trendFallback: 'Tendencia: sin datos.',
+    breakdownLine: (index, name, amount, percentage, count, currency) =>
+      `${index + 1}. ${name} — ${amount} ${currency} (${percentage}%), operaciones: ${count}`,
+    trendLine: (period, total, average, count, currency) =>
+      `${period}: total ${total} ${currency}, ticket medio ${average}, operaciones ${count}`,
+    unnamed: 'Sin nombre',
+    finalInstruction: 'Evita generalidades, aporta conclusiones claras y termina con el siguiente paso recomendado.',
+  },
+  [LANGUAGES.FR]: {
+    intro: 'Tu es un analyste financier attentif et bienveillant.',
+    task: 'À partir des données agrégées, fournis 3-4 observations concrètes et une recommandation actionnable.',
+    format: 'Réponds en français avec des puces concises (chaque ligne commence par "- ").',
+    currencyHeadline: (currency) => `Données en ${currency} :`,
+    metrics: {
+      totalAmount: '• Montant total',
+      totalCount: '• Nombre d’opérations',
+      average: '• Montant moyen',
+      min: '• Montant minimum',
+      max: '• Montant maximum',
+    },
+    categoriesTitle: 'Catégories (top 5) :',
+    categoriesFallback: 'Catégories : aucune donnée.',
+    sourcesTitle: 'Sources de paiement (top 5) :',
+    sourcesFallback: 'Sources de paiement : aucune donnée.',
+    trendTitle: 'Tendance :',
+    trendFallback: 'Tendance : aucune donnée.',
+    breakdownLine: (index, name, amount, percentage, count, currency) =>
+      `${index + 1}. ${name} — ${amount} ${currency} (${percentage}%), opérations : ${count}`,
+    trendLine: (period, total, average, count, currency) =>
+      `${period} : total ${total} ${currency}, montant moyen ${average}, opérations ${count}`,
+    unnamed: 'Sans nom',
+    finalInstruction: 'Évite les généralités, livre des enseignements concrets et propose une étape suivante claire.',
+  },
+};
 
 type RawAggregationSummary = {
   totalAmount?: number;
@@ -56,7 +217,7 @@ export class ExpenseAnalyticsService {
   ) {}
 
   async getAnalytics(userId: string, query: ExpenseAnalyticsQueryDto): Promise<ExpenseAnalyticsResponseDto> {
-    const targetCurrency = await this.resolveTargetCurrency(userId, query.targetCurrency);
+    const { targetCurrency, language } = await this.resolveUserPreferences(userId, query.targetCurrency);
     const granularity = query.trendGranularity ?? AnalyticsTrendGranularity.MONTH;
 
     const matchStage = this.buildMatchStage(userId, query);
@@ -91,7 +252,7 @@ export class ExpenseAnalyticsService {
     let aiInsights: ExpenseAnalyticsAiInsightDto | undefined;
 
     if (query.includeAiAnalysis && summary.totalCount > 0) {
-      aiInsights = await this.generateAiInsights(summary, byCategory, byPaymentSource, trend, targetCurrency);
+      aiInsights = await this.generateAiInsights(summary, byCategory, byPaymentSource, trend, targetCurrency, language);
     }
 
     return {
@@ -520,19 +681,26 @@ export class ExpenseAnalyticsService {
     }, {});
   }
 
-  private async resolveTargetCurrency(userId: string, override?: CURRENCIES): Promise<CURRENCIES> {
-    if (override && Object.values(CURRENCIES).includes(override)) {
-      return override;
-    }
+  private async resolveUserPreferences(
+    userId: string,
+    overrideCurrency?: CURRENCIES,
+  ): Promise<{ targetCurrency: CURRENCIES; language: LANGUAGES }> {
+    const config = await this.userConfigModel.findOne({ userId }).select(['currency', 'language']).lean();
 
-    const config = await this.userConfigModel.findOne({ userId }).select(['currency']).lean();
-    const preferred = config?.currency as CURRENCIES | undefined;
+    const supportedCurrencies = new Set(Object.values(CURRENCIES));
+    const preferredCurrency = config?.currency as CURRENCIES | undefined;
+    const targetCurrency =
+      (overrideCurrency && supportedCurrencies.has(overrideCurrency)) ||
+      (preferredCurrency && supportedCurrencies.has(preferredCurrency))
+        ? (overrideCurrency ?? preferredCurrency)!
+        : CURRENCIES.USD;
 
-    if (preferred && Object.values(CURRENCIES).includes(preferred)) {
-      return preferred;
-    }
+    const storedLanguage = (config?.language as string | undefined)?.toLowerCase() as LANGUAGES | undefined;
+    const language = Object.values(LANGUAGES).includes(storedLanguage ?? LANGUAGES.RU)
+      ? (storedLanguage ?? LANGUAGES.RU)
+      : LANGUAGES.RU;
 
-    return CURRENCIES.USD;
+    return { targetCurrency, language };
   }
 
   private async generateAiInsights(
@@ -541,6 +709,7 @@ export class ExpenseAnalyticsService {
     paymentSources: ExpenseAnalyticsBreakdownItemDto[],
     trend: ExpenseAnalyticsTrendPointDto[],
     targetCurrency: CURRENCIES,
+    language: LANGUAGES,
   ): Promise<ExpenseAnalyticsAiInsightDto | undefined> {
     const apiKey = this.configService.get<string>('GEMINI_API_KEY');
 
@@ -550,7 +719,7 @@ export class ExpenseAnalyticsService {
       return undefined;
     }
 
-    const prompt = this.buildAiPrompt(summary, categories, paymentSources, trend, targetCurrency);
+    const prompt = this.buildAiPrompt(summary, categories, paymentSources, trend, targetCurrency, language);
 
     try {
       const response = await firstValueFrom(
@@ -609,46 +778,62 @@ export class ExpenseAnalyticsService {
     paymentSources: ExpenseAnalyticsBreakdownItemDto[],
     trend: ExpenseAnalyticsTrendPointDto[],
     targetCurrency: CURRENCIES,
+    language: LANGUAGES,
   ): string {
+    const locale = PROMPT_LOCALES[language] ?? PROMPT_LOCALES[LANGUAGES.RU];
+
     const topCategories = categories
       .slice(0, 5)
-      .map(
-        (item, index) =>
-          `${index + 1}. ${item.name ?? 'Без названия'} — ${item.totalAmount.toFixed(
-            2,
-          )} ${targetCurrency} (${item.percentage.toFixed(2)}%), транзакций: ${item.count}`,
+      .map((item, index) =>
+        locale.breakdownLine(
+          index,
+          item.name ?? locale.unnamed,
+          item.totalAmount.toFixed(2),
+          item.percentage.toFixed(2),
+          item.count,
+          targetCurrency,
+          'category',
+        ),
       );
 
     const topSources = paymentSources
       .slice(0, 5)
-      .map(
-        (item, index) =>
-          `${index + 1}. ${item.name ?? 'Без названия'} — ${item.totalAmount.toFixed(
-            2,
-          )} ${targetCurrency} (${item.percentage.toFixed(2)}%), транзакций: ${item.count}`,
+      .map((item, index) =>
+        locale.breakdownLine(
+          index,
+          item.name ?? locale.unnamed,
+          item.totalAmount.toFixed(2),
+          item.percentage.toFixed(2),
+          item.count,
+          targetCurrency,
+          'source',
+        ),
       );
 
-    const trendLines = trend.map(
-      (point) =>
-        `${point.period}: сумма ${point.totalAmount.toFixed(
-          2,
-        )} ${targetCurrency}, средний чек ${point.averageAmount.toFixed(2)}, операций ${point.count}`,
+    const trendLines = trend.map((point) =>
+      locale.trendLine(
+        point.period,
+        point.totalAmount.toFixed(2),
+        point.averageAmount.toFixed(2),
+        point.count,
+        targetCurrency,
+      ),
     );
 
     return [
-      'Ты — дружелюбный персональный финансовый аналитик.',
-      'По аггрегированным данным ниже сделай 3-4 практичных наблюдения и сформулируй 1 рекомендацию.',
-      'Излагай по-русски, компактно, маркированными пунктами (каждый пункт на новой строке, начинай с "- ").',
-      `Данные в валюте ${targetCurrency}:`,
-      `• Общая сумма: ${summary.totalAmount.toFixed(2)}`,
-      `• Количество операций: ${summary.totalCount}`,
-      `• Средний чек: ${summary.averageAmount.toFixed(2)}`,
-      `• Минимальный чек: ${summary.minAmount.toFixed(2)}`,
-      `• Максимальный чек: ${summary.maxAmount.toFixed(2)}`,
-      topCategories.length ? `Категории (топ 5):\n${topCategories.join('\n')}` : 'Категории: нет данных.',
-      topSources.length ? `Источники оплаты (топ 5):\n${topSources.join('\n')}` : 'Источники оплаты: нет данных.',
-      trendLines.length ? `Динамика:\n${trendLines.join('\n')}` : 'Динамика: нет данных.',
-      'Не повторяйся, избегай общих фраз, фокусируйся на выводах и конкретных шагах.',
+      locale.intro,
+      locale.task,
+      locale.format,
+      locale.currencyHeadline(targetCurrency),
+      `${locale.metrics.totalAmount}: ${summary.totalAmount.toFixed(2)}`,
+      `${locale.metrics.totalCount}: ${summary.totalCount}`,
+      `${locale.metrics.average}: ${summary.averageAmount.toFixed(2)}`,
+      `${locale.metrics.min}: ${summary.minAmount.toFixed(2)}`,
+      `${locale.metrics.max}: ${summary.maxAmount.toFixed(2)}`,
+      topCategories.length ? `${locale.categoriesTitle}\n${topCategories.join('\n')}` : locale.categoriesFallback,
+      topSources.length ? `${locale.sourcesTitle}\n${topSources.join('\n')}` : locale.sourcesFallback,
+      trendLines.length ? `${locale.trendTitle}\n${trendLines.join('\n')}` : locale.trendFallback,
+      locale.finalInstruction,
     ].join('\n');
   }
 

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -294,17 +294,17 @@ export class ExpenseAnalyticsService {
     const resolvedStart = query.createdStartDate ? new Date(query.createdStartDate) : defaultStart;
     const resolvedEnd = query.createdEndDate ? new Date(query.createdEndDate) : defaultEnd;
 
-    if (!Number.isNaN(resolvedStart.getTime()) || !Number.isNaN(resolvedEnd.getTime())) {
-      const createdAt: Record<string, Date> = {};
+    const createdAt: { $gte?: Date; $lte?: Date } = {};
 
-      if (!Number.isNaN(resolvedStart.getTime())) {
-        createdAt.$gte = resolvedStart;
-      }
+    if (!Number.isNaN(resolvedStart.getTime())) {
+      createdAt.$gte = resolvedStart;
+    }
 
-      if (!Number.isNaN(resolvedEnd.getTime())) {
-        createdAt.$lte = resolvedEnd;
-      }
+    if (!Number.isNaN(resolvedEnd.getTime())) {
+      createdAt.$lte = resolvedEnd;
+    }
 
+    if (Object.keys(createdAt).length > 0) {
       andConditions.push({ createdAt });
     }
 
@@ -493,19 +493,11 @@ export class ExpenseAnalyticsService {
         };
       case AnalyticsTrendGranularity.WEEK:
         return {
-          $concat: [
-            {
-              $toString: {
-                $isoWeekYear: '$createdAt',
-              },
-            },
-            '-W',
-            {
-              $toString: {
-                $isoWeek: '$createdAt',
-              },
-            },
-          ],
+          $dateToString: {
+            date: '$createdAt',
+            format: '%G-W%V',
+            timezone: 'UTC',
+          },
         };
       case AnalyticsTrendGranularity.YEAR:
         return {

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -681,11 +681,14 @@ export class ExpenseAnalyticsService {
 
     const supportedCurrencies = new Set(Object.values(CURRENCIES));
     const preferredCurrency = config?.currency as CURRENCIES | undefined;
-    const targetCurrency =
-      (overrideCurrency && supportedCurrencies.has(overrideCurrency)) ||
-      (preferredCurrency && supportedCurrencies.has(preferredCurrency))
-        ? (overrideCurrency ?? preferredCurrency)!
-        : CURRENCIES.USD;
+    let targetCurrency: CURRENCIES;
+    if (overrideCurrency && supportedCurrencies.has(overrideCurrency)) {
+      targetCurrency = overrideCurrency;
+    } else if (preferredCurrency && supportedCurrencies.has(preferredCurrency)) {
+      targetCurrency = preferredCurrency;
+    } else {
+      targetCurrency = CURRENCIES.USD;
+    }
 
     const storedLanguage = (config?.language as string | undefined)?.toLowerCase() as LANGUAGES | undefined;
     const language = Object.values(LANGUAGES).includes(storedLanguage)

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -402,7 +402,7 @@ export class ExpenseAnalyticsService {
                     input: '$exchangeRates',
                   },
                 },
-                0,
+                1,
               ],
             },
           ],

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -1,0 +1,681 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, PipelineStage, Types } from 'mongoose';
+import { firstValueFrom } from 'rxjs';
+import { Expense } from './models/expense.model';
+import { Category, CategoryDocument } from '../category/models/category.model';
+import { PaymentSource, PaymentSourceDocument } from '../payment-source/models/payment-source.model';
+import { UserConfig, UserConfigDocument } from '../user-config/model/user-config.model';
+import { AnalyticsTrendGranularity, ExpenseAnalyticsQueryDto } from './dto/expense-analytics-query.dto';
+import {
+  ExpenseAnalyticsAiInsightDto,
+  ExpenseAnalyticsAppliedFiltersDto,
+  ExpenseAnalyticsBreakdownItemDto,
+  ExpenseAnalyticsResponseDto,
+  ExpenseAnalyticsSummaryDto,
+  ExpenseAnalyticsTrendPointDto,
+} from './dto/expense-analytics-response.dto';
+import { CURRENCIES } from '../../common/interfaces/currencies.enum';
+
+type RawAggregationSummary = {
+  totalAmount?: number;
+  totalCount?: number;
+  averageAmount?: number;
+  minAmount?: number;
+  maxAmount?: number;
+};
+
+type RawAggregationBreakdown = {
+  _id: string | null;
+  totalAmount: number;
+  count: number;
+};
+
+type RawAggregationTimeline = {
+  _id: string;
+  totalAmount: number;
+  averageAmount: number;
+  count: number;
+};
+
+@Injectable()
+export class ExpenseAnalyticsService {
+  private readonly logger = new Logger(ExpenseAnalyticsService.name);
+  private readonly modelId = 'gemini-2.0-flash-001';
+  private readonly endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${this.modelId}:generateContent`;
+
+  constructor(
+    @InjectModel(Expense.name) private readonly expenseModel: Model<Expense>,
+    @InjectModel(Category.name) private readonly categoryModel: Model<CategoryDocument>,
+    @InjectModel(PaymentSource.name) private readonly paymentSourceModel: Model<PaymentSourceDocument>,
+    @InjectModel(UserConfig.name) private readonly userConfigModel: Model<UserConfigDocument>,
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async getAnalytics(userId: string, query: ExpenseAnalyticsQueryDto): Promise<ExpenseAnalyticsResponseDto> {
+    const targetCurrency = await this.resolveTargetCurrency(userId, query.targetCurrency);
+    const granularity = query.trendGranularity ?? AnalyticsTrendGranularity.MONTH;
+
+    const matchStage = this.buildMatchStage(userId, query);
+    const pipeline = this.buildAggregationPipeline(matchStage, targetCurrency, granularity);
+
+    const aggregation = await this.aggregateExpenses(pipeline);
+
+    const summary = this.buildSummary(aggregation.summary?.[0], targetCurrency);
+
+    const categoryIds = (aggregation.categoryBreakdown ?? [])
+      .map((item) => item._id)
+      .filter((id): id is string => Boolean(id));
+    const paymentSourceIds = (aggregation.paymentSourceBreakdown ?? [])
+      .map((item) => item._id)
+      .filter((id): id is string => Boolean(id));
+
+    const [categoryNames, paymentSourceNames] = await Promise.all([
+      this.resolveCategoryNames(categoryIds),
+      this.resolvePaymentSourceNames(paymentSourceIds),
+    ]);
+
+    const byCategory = this.buildBreakdown(aggregation.categoryBreakdown ?? [], summary.totalAmount, categoryNames);
+    const byPaymentSource = this.buildBreakdown(
+      aggregation.paymentSourceBreakdown ?? [],
+      summary.totalAmount,
+      paymentSourceNames,
+    );
+    const trend = this.buildTrend(aggregation.timeline ?? [], granularity);
+
+    const appliedFilters = this.buildAppliedFilters(query, matchStage, targetCurrency, granularity);
+
+    let aiInsights: ExpenseAnalyticsAiInsightDto | undefined;
+
+    if (query.includeAiAnalysis && summary.totalCount > 0) {
+      aiInsights = await this.generateAiInsights(summary, byCategory, byPaymentSource, trend, targetCurrency);
+    }
+
+    return {
+      summary,
+      byCategory,
+      byPaymentSource,
+      trend,
+      appliedFilters,
+      aiInsights,
+    };
+  }
+
+  private async aggregateExpenses(pipeline: PipelineStage[]): Promise<{
+    summary?: RawAggregationSummary[];
+    categoryBreakdown?: RawAggregationBreakdown[];
+    paymentSourceBreakdown?: RawAggregationBreakdown[];
+    timeline?: RawAggregationTimeline[];
+  }> {
+    const [result] = (await this.expenseModel.aggregate(pipeline).allowDiskUse(true).exec()) ?? [];
+
+    return (
+      result ?? {
+        summary: [],
+        categoryBreakdown: [],
+        paymentSourceBreakdown: [],
+        timeline: [],
+      }
+    );
+  }
+
+  private buildMatchStage(userId: string, query: ExpenseAnalyticsQueryDto): Record<string, unknown> {
+    const match: Record<string, unknown> = { userId };
+    const andConditions: Record<string, unknown>[] = [];
+
+    const now = new Date();
+    const defaultStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+    const defaultEnd = now;
+
+    const resolvedStart = query.createdStartDate ? new Date(query.createdStartDate) : defaultStart;
+    const resolvedEnd = query.createdEndDate ? new Date(query.createdEndDate) : defaultEnd;
+
+    if (!Number.isNaN(resolvedStart.getTime()) || !Number.isNaN(resolvedEnd.getTime())) {
+      const createdAt: Record<string, Date> = {};
+
+      if (!Number.isNaN(resolvedStart.getTime())) {
+        createdAt.$gte = resolvedStart;
+      }
+
+      if (!Number.isNaN(resolvedEnd.getTime())) {
+        createdAt.$lte = resolvedEnd;
+      }
+
+      andConditions.push({ createdAt });
+    }
+
+    const singleCategoryId = query.categoryId;
+    const categorySet = new Set<string>(query.categoryIds ?? []);
+
+    if (singleCategoryId) {
+      categorySet.add(singleCategoryId);
+    }
+
+    if (categorySet.size === 1) {
+      match.categoryId = [...categorySet][0];
+    } else if (categorySet.size > 1) {
+      match.categoryId = { $in: [...categorySet] };
+    }
+
+    const singlePaymentSourceId = query.paymentSourceId;
+    const paymentSourceSet = new Set<string>(query.paymentSourceIds ?? []);
+
+    if (singlePaymentSourceId) {
+      paymentSourceSet.add(singlePaymentSourceId);
+    }
+
+    if (paymentSourceSet.size === 1) {
+      match.paymentSourceId = [...paymentSourceSet][0];
+    } else if (paymentSourceSet.size > 1) {
+      match.paymentSourceId = { $in: [...paymentSourceSet] };
+    }
+
+    if (typeof query.amountStart === 'number' || typeof query.amountEnd === 'number') {
+      const amount: Record<string, number> = {};
+
+      if (typeof query.amountStart === 'number') {
+        amount.$gte = query.amountStart;
+      }
+
+      if (typeof query.amountEnd === 'number') {
+        amount.$lte = query.amountEnd;
+      }
+
+      match.amount = amount;
+    }
+
+    if (query.currencies && query.currencies.length > 0) {
+      match.currency = { $in: query.currencies };
+    }
+
+    if (typeof query.hasComments === 'boolean') {
+      if (query.hasComments) {
+        andConditions.push({
+          comments: {
+            $exists: true,
+            $type: 'string',
+            $ne: '',
+          },
+        });
+      } else {
+        andConditions.push({
+          $or: [{ comments: { $exists: false } }, { comments: { $eq: '' } }, { comments: { $type: 'null' } }],
+        });
+      }
+    }
+
+    if (query.searchTerm) {
+      andConditions.push({
+        comments: {
+          $regex: query.searchTerm,
+          $options: 'i',
+        },
+      });
+    }
+
+    if (andConditions.length) {
+      match.$and = andConditions;
+    }
+
+    return match;
+  }
+
+  private buildAggregationPipeline(
+    matchStage: Record<string, unknown>,
+    targetCurrency: CURRENCIES,
+    granularity: AnalyticsTrendGranularity,
+  ): PipelineStage[] {
+    const amountInTarget = {
+      $round: [
+        {
+          $multiply: [
+            '$amount',
+            {
+              $ifNull: [
+                {
+                  $getField: {
+                    field: targetCurrency,
+                    input: '$exchangeRates',
+                  },
+                },
+                0,
+              ],
+            },
+          ],
+        },
+        2,
+      ],
+    };
+
+    return [
+      { $match: matchStage },
+      {
+        $addFields: {
+          amountInTarget,
+          trendKey: this.buildTrendKeyExpression(granularity),
+        },
+      },
+      {
+        $facet: {
+          summary: [
+            {
+              $group: {
+                _id: null,
+                totalAmount: { $sum: '$amountInTarget' },
+                totalCount: { $sum: 1 },
+                averageAmount: { $avg: '$amountInTarget' },
+                minAmount: { $min: '$amountInTarget' },
+                maxAmount: { $max: '$amountInTarget' },
+              },
+            },
+          ],
+          categoryBreakdown: [
+            {
+              $group: {
+                _id: '$categoryId',
+                totalAmount: { $sum: '$amountInTarget' },
+                count: { $sum: 1 },
+              },
+            },
+            {
+              $sort: {
+                totalAmount: -1,
+              },
+            },
+          ],
+          paymentSourceBreakdown: [
+            {
+              $group: {
+                _id: '$paymentSourceId',
+                totalAmount: { $sum: '$amountInTarget' },
+                count: { $sum: 1 },
+              },
+            },
+            {
+              $sort: {
+                totalAmount: -1,
+              },
+            },
+          ],
+          timeline: [
+            {
+              $group: {
+                _id: '$trendKey',
+                totalAmount: { $sum: '$amountInTarget' },
+                averageAmount: { $avg: '$amountInTarget' },
+                count: { $sum: 1 },
+              },
+            },
+            {
+              $sort: {
+                _id: 1,
+              },
+            },
+          ],
+        },
+      },
+    ];
+  }
+
+  private buildTrendKeyExpression(granularity: AnalyticsTrendGranularity): Record<string, unknown> {
+    switch (granularity) {
+      case AnalyticsTrendGranularity.DAY:
+        return {
+          $dateToString: {
+            date: '$createdAt',
+            format: '%Y-%m-%d',
+            timezone: 'UTC',
+          },
+        };
+      case AnalyticsTrendGranularity.WEEK:
+        return {
+          $concat: [
+            {
+              $toString: {
+                $isoWeekYear: '$createdAt',
+              },
+            },
+            '-W',
+            {
+              $toString: {
+                $isoWeek: '$createdAt',
+              },
+            },
+          ],
+        };
+      case AnalyticsTrendGranularity.YEAR:
+        return {
+          $dateToString: {
+            date: '$createdAt',
+            format: '%Y',
+            timezone: 'UTC',
+          },
+        };
+      case AnalyticsTrendGranularity.MONTH:
+      default:
+        return {
+          $dateToString: {
+            date: '$createdAt',
+            format: '%Y-%m',
+            timezone: 'UTC',
+          },
+        };
+    }
+  }
+
+  private buildSummary(raw: RawAggregationSummary | undefined, currency: CURRENCIES): ExpenseAnalyticsSummaryDto {
+    if (!raw) {
+      return {
+        totalAmount: 0,
+        totalCount: 0,
+        averageAmount: 0,
+        minAmount: 0,
+        maxAmount: 0,
+        currency,
+      };
+    }
+
+    return {
+      totalAmount: this.round(raw.totalAmount ?? 0),
+      totalCount: raw.totalCount ?? 0,
+      averageAmount: this.round(raw.averageAmount ?? 0),
+      minAmount: this.round(raw.minAmount ?? 0),
+      maxAmount: this.round(raw.maxAmount ?? 0),
+      currency,
+    };
+  }
+
+  private buildBreakdown(
+    raw: RawAggregationBreakdown[],
+    totalAmount: number,
+    names: Record<string, string>,
+  ): ExpenseAnalyticsBreakdownItemDto[] {
+    if (!raw || raw.length === 0) {
+      return [];
+    }
+
+    return raw.map((item) => {
+      const percentage = totalAmount > 0 ? this.round((item.totalAmount / totalAmount) * 100) : 0;
+      const id = item._id ?? 'unknown';
+
+      return {
+        id,
+        name: names[id] ?? null,
+        totalAmount: this.round(item.totalAmount),
+        percentage,
+        count: item.count,
+      };
+    });
+  }
+
+  private buildTrend(
+    raw: RawAggregationTimeline[],
+    granularity: AnalyticsTrendGranularity,
+  ): ExpenseAnalyticsTrendPointDto[] {
+    if (!raw || raw.length === 0) {
+      return [];
+    }
+
+    return raw.map((item) => ({
+      period: item._id,
+      totalAmount: this.round(item.totalAmount),
+      averageAmount: this.round(item.averageAmount),
+      count: item.count,
+    }));
+  }
+
+  private buildAppliedFilters(
+    query: ExpenseAnalyticsQueryDto,
+    matchStage: Record<string, unknown>,
+    targetCurrency: CURRENCIES,
+    granularity: AnalyticsTrendGranularity,
+  ): ExpenseAnalyticsAppliedFiltersDto {
+    const categoryIds = new Set<string>();
+
+    if (query.categoryId) {
+      categoryIds.add(query.categoryId);
+    }
+
+    (query.categoryIds ?? []).forEach((id) => categoryIds.add(id));
+
+    const paymentSourceIds = new Set<string>();
+
+    if (query.paymentSourceId) {
+      paymentSourceIds.add(query.paymentSourceId);
+    }
+
+    (query.paymentSourceIds ?? []).forEach((id) => paymentSourceIds.add(id));
+
+    const createdAtCondition = Array.isArray(matchStage.$and)
+      ? (matchStage.$and as Record<string, unknown>[]).find(
+          (condition): condition is { createdAt: { $gte?: Date; $lte?: Date } } =>
+            typeof condition === 'object' && condition !== null && 'createdAt' in condition,
+        )
+      : undefined;
+
+    const createdAtRange = createdAtCondition?.createdAt;
+
+    return {
+      categoryIds: categoryIds.size ? [...categoryIds] : undefined,
+      paymentSourceIds: paymentSourceIds.size ? [...paymentSourceIds] : undefined,
+      currencies: query.currencies,
+      createdStartDate: createdAtRange?.$gte?.toISOString() ?? null,
+      createdEndDate: createdAtRange?.$lte?.toISOString() ?? null,
+      amountStart: typeof query.amountStart === 'number' ? query.amountStart : null,
+      amountEnd: typeof query.amountEnd === 'number' ? query.amountEnd : null,
+      hasComments: typeof query.hasComments === 'boolean' ? query.hasComments : null,
+      searchTerm: query.searchTerm ?? null,
+      trendGranularity: granularity,
+      targetCurrency,
+    };
+  }
+
+  private async resolveCategoryNames(ids: string[]): Promise<Record<string, string>> {
+    if (!ids.length) {
+      return {};
+    }
+
+    const objectIds = ids.filter((id) => Types.ObjectId.isValid(id)).map((id) => new Types.ObjectId(id));
+
+    if (!objectIds.length) {
+      return {};
+    }
+
+    const categories = await this.categoryModel
+      .find({ _id: { $in: objectIds } })
+      .select(['title'])
+      .lean();
+
+    return categories.reduce<Record<string, string>>((acc, category) => {
+      acc[(category._id as unknown as Types.ObjectId).toString()] = category.title;
+
+      return acc;
+    }, {});
+  }
+
+  private async resolvePaymentSourceNames(ids: string[]): Promise<Record<string, string>> {
+    if (!ids.length) {
+      return {};
+    }
+
+    const objectIds = ids.filter((id) => Types.ObjectId.isValid(id)).map((id) => new Types.ObjectId(id));
+
+    if (!objectIds.length) {
+      return {};
+    }
+
+    const paymentSources = await this.paymentSourceModel
+      .find({ _id: { $in: objectIds } })
+      .select(['title'])
+      .lean();
+
+    return paymentSources.reduce<Record<string, string>>((acc, source) => {
+      const key = (source._id as unknown as Types.ObjectId).toString();
+      acc[key] = source.title;
+
+      return acc;
+    }, {});
+  }
+
+  private async resolveTargetCurrency(userId: string, override?: CURRENCIES): Promise<CURRENCIES> {
+    if (override && Object.values(CURRENCIES).includes(override)) {
+      return override;
+    }
+
+    const config = await this.userConfigModel.findOne({ userId }).select(['currency']).lean();
+    const preferred = config?.currency as CURRENCIES | undefined;
+
+    if (preferred && Object.values(CURRENCIES).includes(preferred)) {
+      return preferred;
+    }
+
+    return CURRENCIES.USD;
+  }
+
+  private async generateAiInsights(
+    summary: ExpenseAnalyticsSummaryDto,
+    categories: ExpenseAnalyticsBreakdownItemDto[],
+    paymentSources: ExpenseAnalyticsBreakdownItemDto[],
+    trend: ExpenseAnalyticsTrendPointDto[],
+    targetCurrency: CURRENCIES,
+  ): Promise<ExpenseAnalyticsAiInsightDto | undefined> {
+    const apiKey = this.configService.get<string>('GEMINI_API_KEY');
+
+    if (!apiKey) {
+      this.logger.warn('GEMINI_API_KEY is not configured. Skipping AI analytics generation.');
+
+      return undefined;
+    }
+
+    const prompt = this.buildAiPrompt(summary, categories, paymentSources, trend, targetCurrency);
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(
+          this.endpoint,
+          {
+            contents: [
+              {
+                role: 'user',
+                parts: [
+                  {
+                    text: prompt,
+                  },
+                ],
+              },
+            ],
+            generationConfig: {
+              temperature: 0.3,
+              responseMimeType: 'text/plain',
+            },
+          },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-goog-api-key': apiKey,
+            },
+            timeout: 10000,
+          },
+        ),
+      );
+
+      const insightText = this.extractCandidateText(response?.data);
+
+      if (!insightText) {
+        this.logger.warn('Gemini response did not contain analyzable text.');
+
+        return undefined;
+      }
+
+      return {
+        summary: insightText.trim(),
+        generatedAt: new Date().toISOString(),
+        model: this.modelId,
+      };
+    } catch (error) {
+      const err = error as Error & { response?: { status?: number; data?: unknown } };
+      this.logger.error(`Failed to generate AI analytics (status: ${err.response?.status ?? 'unknown'})`, err.message);
+
+      return undefined;
+    }
+  }
+
+  private buildAiPrompt(
+    summary: ExpenseAnalyticsSummaryDto,
+    categories: ExpenseAnalyticsBreakdownItemDto[],
+    paymentSources: ExpenseAnalyticsBreakdownItemDto[],
+    trend: ExpenseAnalyticsTrendPointDto[],
+    targetCurrency: CURRENCIES,
+  ): string {
+    const topCategories = categories
+      .slice(0, 5)
+      .map(
+        (item, index) =>
+          `${index + 1}. ${item.name ?? 'Без названия'} — ${item.totalAmount.toFixed(
+            2,
+          )} ${targetCurrency} (${item.percentage.toFixed(2)}%), транзакций: ${item.count}`,
+      );
+
+    const topSources = paymentSources
+      .slice(0, 5)
+      .map(
+        (item, index) =>
+          `${index + 1}. ${item.name ?? 'Без названия'} — ${item.totalAmount.toFixed(
+            2,
+          )} ${targetCurrency} (${item.percentage.toFixed(2)}%), транзакций: ${item.count}`,
+      );
+
+    const trendLines = trend.map(
+      (point) =>
+        `${point.period}: сумма ${point.totalAmount.toFixed(
+          2,
+        )} ${targetCurrency}, средний чек ${point.averageAmount.toFixed(2)}, операций ${point.count}`,
+    );
+
+    return [
+      'Ты — дружелюбный персональный финансовый аналитик.',
+      'По аггрегированным данным ниже сделай 3-4 практичных наблюдения и сформулируй 1 рекомендацию.',
+      'Излагай по-русски, компактно, маркированными пунктами (каждый пункт на новой строке, начинай с "- ").',
+      `Данные в валюте ${targetCurrency}:`,
+      `• Общая сумма: ${summary.totalAmount.toFixed(2)}`,
+      `• Количество операций: ${summary.totalCount}`,
+      `• Средний чек: ${summary.averageAmount.toFixed(2)}`,
+      `• Минимальный чек: ${summary.minAmount.toFixed(2)}`,
+      `• Максимальный чек: ${summary.maxAmount.toFixed(2)}`,
+      topCategories.length ? `Категории (топ 5):\n${topCategories.join('\n')}` : 'Категории: нет данных.',
+      topSources.length ? `Источники оплаты (топ 5):\n${topSources.join('\n')}` : 'Источники оплаты: нет данных.',
+      trendLines.length ? `Динамика:\n${trendLines.join('\n')}` : 'Динамика: нет данных.',
+      'Не повторяйся, избегай общих фраз, фокусируйся на выводах и конкретных шагах.',
+    ].join('\n');
+  }
+
+  private extractCandidateText(responseData: unknown): string | undefined {
+    if (
+      typeof responseData === 'object' &&
+      responseData !== null &&
+      'candidates' in responseData &&
+      Array.isArray((responseData as Record<string, unknown>)['candidates'])
+    ) {
+      const candidate = (responseData as { candidates: Array<Record<string, unknown>> }).candidates[0];
+      const content = candidate?.content as { parts?: Array<{ text?: string }> } | undefined;
+      const parts = content?.parts;
+
+      if (Array.isArray(parts) && parts.length > 0) {
+        const textPart = parts.find((part) => typeof part?.text === 'string');
+
+        if (textPart?.text) {
+          return textPart.text;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private round(value: number): number {
+    return Math.round((value + Number.EPSILON) * 100) / 100;
+  }
+}

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -682,6 +682,7 @@ export class ExpenseAnalyticsService {
     const supportedCurrencies = new Set(Object.values(CURRENCIES));
     const preferredCurrency = config?.currency as CURRENCIES | undefined;
     let targetCurrency: CURRENCIES;
+
     if (overrideCurrency && supportedCurrencies.has(overrideCurrency)) {
       targetCurrency = overrideCurrency;
     } else if (preferredCurrency && supportedCurrencies.has(preferredCurrency)) {
@@ -691,9 +692,7 @@ export class ExpenseAnalyticsService {
     }
 
     const storedLanguage = (config?.language as string | undefined)?.toLowerCase() as LANGUAGES | undefined;
-    const language = Object.values(LANGUAGES).includes(storedLanguage)
-      ? storedLanguage
-      : LANGUAGES.RU;
+    const language = Object.values(LANGUAGES).includes(storedLanguage) ? storedLanguage : LANGUAGES.RU;
 
     return { targetCurrency, language };
   }

--- a/src/app/expense/expense-analytics.service.ts
+++ b/src/app/expense/expense-analytics.service.ts
@@ -688,8 +688,8 @@ export class ExpenseAnalyticsService {
         : CURRENCIES.USD;
 
     const storedLanguage = (config?.language as string | undefined)?.toLowerCase() as LANGUAGES | undefined;
-    const language = Object.values(LANGUAGES).includes(storedLanguage ?? LANGUAGES.RU)
-      ? (storedLanguage ?? LANGUAGES.RU)
+    const language = Object.values(LANGUAGES).includes(storedLanguage)
+      ? storedLanguage
       : LANGUAGES.RU;
 
     return { targetCurrency, language };

--- a/src/app/expense/expense.controller.ts
+++ b/src/app/expense/expense.controller.ts
@@ -35,6 +35,10 @@ import { GetExpenseByFamilyBudgetSwDec } from './decorators/get-expense-by-famil
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ReceiptParseResponseDto } from './dto/receipt-expense-response.dto';
 import { ParseReceiptSwDec } from './decorators/parse-receipt-sw.decorator';
+import { ExpenseAnalyticsService } from './expense-analytics.service';
+import { ExpenseAnalyticsQueryDto } from './dto/expense-analytics-query.dto';
+import { ExpenseAnalyticsResponseDto } from './dto/expense-analytics-response.dto';
+import { GetExpenseAnalyticsSwDec } from './decorators/get-expense-analytics-sw.decorator';
 
 @UseGuards(AccessJwtGuard)
 @ApiTags('Expense')
@@ -43,12 +47,22 @@ export class ExpenseController {
   constructor(
     private readonly expenseService: ExpenseService,
     private readonly receiptAiService: ReceiptAiService,
+    private readonly expenseAnalyticsService: ExpenseAnalyticsService,
   ) {}
 
   @GetExpenseSwDec()
   @Get()
   async getOwn(@Query() queryInputDto: ExpenseQueryInputDto, @Req() req: CustomRequest): Promise<ExpenseOutputDto[]> {
     return this.expenseService.getOwn(req.user.userId, queryInputDto);
+  }
+
+  @GetExpenseAnalyticsSwDec()
+  @Get('analytics')
+  async getAnalytics(
+    @Query() query: ExpenseAnalyticsQueryDto,
+    @Req() req: CustomRequest,
+  ): Promise<ExpenseAnalyticsResponseDto> {
+    return this.expenseAnalyticsService.getAnalytics(req.user.userId, query);
   }
 
   @GetExpenseByIdSwDec()

--- a/src/app/expense/expense.module.ts
+++ b/src/app/expense/expense.module.ts
@@ -16,6 +16,7 @@ import { ExpenseService } from './expense.service';
 import { ReceiptAiService } from './receipt-ai.service';
 import { ExpansesSchema, Expense } from './models/expense.model';
 import { CronExpenseModule } from '../cron-expenses/cron-expense.module';
+import { ExpenseAnalyticsService } from './expense-analytics.service';
 
 @Module({
   imports: [
@@ -32,7 +33,7 @@ import { CronExpenseModule } from '../cron-expenses/cron-expense.module';
     forwardRef(() => CronExpenseModule),
   ],
   controllers: [ExpenseController],
-  providers: [ExpenseService, ReceiptAiService, AccessControlService, AccessJwtStrategy],
+  providers: [ExpenseService, ReceiptAiService, ExpenseAnalyticsService, AccessControlService, AccessJwtStrategy],
   exports: [ExpenseService],
 })
 export class ExpenseModule {}


### PR DESCRIPTION
  - Добавлен эндпойнт `/expense/analytics` с расширенными фильтрами, нормализацией сумм по валюте и
    опциональным обзором от Gemini ИИ (src/app/expense/...).
  - Созданы DTO и Swagger-декораторы, позволяющие выбирать несколько категорий/источников, искать
    по комментариям, управлять шагом тренда и включать AI-анализ (`src/app/expense/dto/*.ts` , `src/
    app/expense/decorators/get-expense-analytics-sw.decorator.ts` ).
  - Реализован `ExpenseAnalyticsService` , который выполняет Mongo-агрегации, подтягивает названия
    категорий/источников и генерирует инсайты при наличии API-ключа ( `src/app/expense/expense-
    analytics.service.ts` ).
  - Добавлен интеграционный тест, развертывающий рабочий контур и проверяющий ответ `GET /api/
    expense/analytics` целиком ( `src/app/expense/expense-analytics.controller.spec.ts` ).